### PR TITLE
Correct the callback name in downloadDictionary

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ var downloadDictionary = (url, file, callback) => {
     });
   }).on('error', function(err) {
     fs.unlink(file);
-    if (callback) cb(err.message);
+    if (callback) callback(err.message);
   });
 };
 

--- a/server.js
+++ b/server.js
@@ -34,17 +34,17 @@ var dictionaryHandler = (request, response) => {
 }
 
 var downloadDictionary = (url, file, callback) => {
-  var stream = fs.createWriteStream(file);
-  var req = https.get(url, function(res) {
-    res.pipe(stream);
-    stream.on('finish', function() {
-      stream.close(callback);
-      console.log('dictionary downloaded');
+    var stream = fs.createWriteStream(file);
+    var req = https.get(url, function(res) {
+        res.pipe(stream);
+        stream.on('finish', function() {
+            stream.close(callback);
+            console.log('dictionary downloaded');
+        });
+    }).on('error', function(err) {
+        fs.unlink(file);
+        if (callback) callback(err.message);
     });
-  }).on('error', function(err) {
-    fs.unlink(file);
-    if (callback) callback(err.message);
-  });
 };
 
 var loadDictionary = (file, callback) => {
@@ -77,9 +77,9 @@ downloadDictionary('https://raw.githubusercontent.com/adambom/dictionary/master/
 const server = http.createServer(dictionaryHandler);
 
 server.listen(8080, (err) => {  
-  if (err) {
-    return console.log('error starting server: ' + err);
-  }
+    if (err) {
+        return console.log('error starting server: ' + err);
+    }
 
-  console.log('server is listening on 8080');
+    console.log('server is listening on 8080');
 });


### PR DESCRIPTION
The error path in `downloadDictionary` can be triggered with the latest version of _microk8s_, by not allowing traffic forwarding (allowed with: `sudo iptables -P FORWARD ACCEPT`). In that case, name resolution within pods won't be working and the following error message will be correctly produced, as a consequence of this PR, when trying to download the dictionary:
`getaddrinfo ENOTFOUND raw.githubusercontent.com raw.githubusercontent.com:443`

Ref: https://github.com/ubuntu/microk8s/issues/75